### PR TITLE
Create courier company data table

### DIFF
--- a/fa_express_company.sql
+++ b/fa_express_company.sql
@@ -1,0 +1,35 @@
+-- FastAdmin 快递公司数据表
+-- 表名：fa_express_company
+
+DROP TABLE IF EXISTS `fa_express_company`;
+
+CREATE TABLE `fa_express_company` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+  `express_type` varchar(50) NOT NULL DEFAULT '' COMMENT '快递类型',
+  `company_name` varchar(100) NOT NULL DEFAULT '' COMMENT '快递公司名称',
+  `company_code` varchar(50) NOT NULL DEFAULT '' COMMENT '快递公司代码',
+  `payment_type` enum('现结','月结') NOT NULL DEFAULT '现结' COMMENT '结算方式',
+  `contact_person` varchar(50) NOT NULL DEFAULT '' COMMENT '联系人',
+  `contact_phone` varchar(20) NOT NULL DEFAULT '' COMMENT '联系电话',
+  `contact_address` varchar(255) NOT NULL DEFAULT '' COMMENT '联系地址',
+  `service_area` text COMMENT '服务区域',
+  `price_info` text COMMENT '价格信息',
+  `remark` text COMMENT '备注',
+  `status` enum('normal','hidden') NOT NULL DEFAULT 'normal' COMMENT '状态',
+  `weigh` int(10) NOT NULL DEFAULT 0 COMMENT '权重',
+  `createtime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT '创建时间',
+  `updatetime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  KEY `weigh` (`weigh`,`id`),
+  KEY `status` (`status`),
+  KEY `express_type` (`express_type`),
+  KEY `payment_type` (`payment_type`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='快递公司表';
+
+-- 插入一些示例数据
+INSERT INTO `fa_express_company` (`id`, `express_type`, `company_name`, `company_code`, `payment_type`, `contact_person`, `contact_phone`, `contact_address`, `service_area`, `price_info`, `remark`, `status`, `weigh`, `createtime`, `updatetime`) VALUES
+(1, '标准快递', '顺丰速运', 'SF', '月结', '张经理', '400-111-1111', '深圳市福田区', '全国', '首重12元/kg，续重2元/kg', '时效快，服务好', 'normal', 100, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(2, '标准快递', '中通快递', 'ZTO', '现结', '李经理', '400-222-2222', '上海市青浦区', '全国', '首重8元/kg，续重1.5元/kg', '性价比高', 'normal', 90, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(3, '标准快递', '韵达快递', 'YD', '月结', '王经理', '400-333-3333', '上海市青浦区', '全国', '首重8元/kg，续重1.5元/kg', '网点覆盖广', 'normal', 80, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(4, '同城快递', '闪送', 'SS', '现结', '刘经理', '400-444-4444', '北京市朝阳区', '同城', '起步价12元，超出按距离计费', '同城即时配送', 'normal', 70, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(5, '国际快递', 'DHL', 'DHL', '月结', '陈经理', '400-555-5555', '上海市浦东新区', '国际', '按重量和目的地计费', '国际快递领先品牌', 'normal', 60, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());

--- a/fa_express_simple.sql
+++ b/fa_express_simple.sql
@@ -1,0 +1,34 @@
+-- FastAdmin 快递公司数据表（简化版）
+-- 表名：fa_express_simple
+-- 只包含核心字段：快递类型、快递公司、现结或月结
+
+DROP TABLE IF EXISTS `fa_express_simple`;
+
+CREATE TABLE `fa_express_simple` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+  `express_type` varchar(50) NOT NULL DEFAULT '' COMMENT '快递类型',
+  `company_name` varchar(100) NOT NULL DEFAULT '' COMMENT '快递公司',
+  `payment_type` enum('现结','月结') NOT NULL DEFAULT '现结' COMMENT '结算方式',
+  `status` enum('normal','hidden') NOT NULL DEFAULT 'normal' COMMENT '状态',
+  `weigh` int(10) NOT NULL DEFAULT 0 COMMENT '权重',
+  `createtime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT '创建时间',
+  `updatetime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  KEY `weigh` (`weigh`,`id`),
+  KEY `status` (`status`),
+  KEY `express_type` (`express_type`),
+  KEY `payment_type` (`payment_type`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='快递公司表（简化版）';
+
+-- 插入示例数据
+INSERT INTO `fa_express_simple` (`id`, `express_type`, `company_name`, `payment_type`, `status`, `weigh`, `createtime`, `updatetime`) VALUES
+(1, '标准快递', '顺丰速运', '月结', 'normal', 100, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(2, '标准快递', '中通快递', '现结', 'normal', 90, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(3, '标准快递', '韵达快递', '月结', 'normal', 80, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(4, '标准快递', '圆通快递', '现结', 'normal', 70, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(5, '标准快递', '申通快递', '月结', 'normal', 60, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(6, '同城快递', '闪送', '现结', 'normal', 50, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(7, '同城快递', '达达快送', '现结', 'normal', 40, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(8, '国际快递', 'DHL', '月结', 'normal', 30, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(9, '国际快递', 'FedEx', '月结', 'normal', 20, UNIX_TIMESTAMP(), UNIX_TIMESTAMP()),
+(10, '国际快递', 'UPS', '月结', 'normal', 10, UNIX_TIMESTAMP(), UNIX_TIMESTAMP());

--- a/快递公司数据表说明.md
+++ b/快递公司数据表说明.md
@@ -1,0 +1,73 @@
+# FastAdmin 快递公司数据表说明
+
+## 概述
+我为您创建了两个版本的快递公司数据表，您可以根据实际需求选择使用：
+
+## 版本1：完整版数据表 (fa_express_company.sql)
+**表名：** `fa_express_company`
+
+**主要字段：**
+- `id` - 主键ID
+- `express_type` - 快递类型（如：标准快递、同城快递、国际快递）
+- `company_name` - 快递公司名称
+- `company_code` - 快递公司代码
+- `payment_type` - 结算方式（现结/月结）
+- `contact_person` - 联系人
+- `contact_phone` - 联系电话
+- `contact_address` - 联系地址
+- `service_area` - 服务区域
+- `price_info` - 价格信息
+- `remark` - 备注
+- `status` - 状态（normal/hidden）
+- `weigh` - 权重排序
+- `createtime` - 创建时间
+- `updatetime` - 更新时间
+
+**特点：**
+- 包含完整的快递公司信息
+- 支持联系方式管理
+- 支持价格信息记录
+- 适合需要详细管理快递公司信息的场景
+
+## 版本2：简化版数据表 (fa_express_simple.sql)
+**表名：** `fa_express_simple`
+
+**主要字段：**
+- `id` - 主键ID
+- `express_type` - 快递类型
+- `company_name` - 快递公司
+- `payment_type` - 结算方式（现结/月结）
+- `status` - 状态
+- `weigh` - 权重排序
+- `createtime` - 创建时间
+- `updatetime` - 更新时间
+
+**特点：**
+- 只包含您要求的核心字段
+- 结构简洁，便于维护
+- 适合基础的快递公司管理需求
+
+## 快递类型分类
+- **标准快递：** 顺丰、中通、韵达、圆通、申通等
+- **同城快递：** 闪送、达达快送等
+- **国际快递：** DHL、FedEx、UPS等
+
+## 结算方式
+- **现结：** 货到付款，即时结算
+- **月结：** 月度统一结算，通常有信用额度
+
+## 使用建议
+1. **如果您需要完整的快递公司信息管理，推荐使用 `fa_express_company` 表**
+2. **如果只需要基础的快递公司分类和结算方式，推荐使用 `fa_express_simple` 表**
+3. **两个表都符合FastAdmin的标准规范，包含必要的索引和约束**
+
+## 安装方法
+1. 将对应的SQL文件导入到您的MySQL数据库中
+2. 确保数据库编码为utf8mb4
+3. 执行SQL文件即可创建表结构和示例数据
+
+## 注意事项
+- 表名以 `fa_` 开头，符合FastAdmin规范
+- 使用了enum类型来限制结算方式的选择
+- 包含了适当的索引以提高查询性能
+- 时间字段使用了UNIX时间戳格式


### PR DESCRIPTION
Add FastAdmin compatible SQL schemas for express company data, including a full and a simplified version, based on user requirements.

The user requested a FastAdmin-compatible data table for express companies with specific fields. Two versions are provided to offer flexibility: a simplified one with only the requested core fields and a more comprehensive one for broader use cases, along with a detailed explanation document.